### PR TITLE
Added CI (Continuous Integration) config file for service "travis-ci.org"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+# command to install dependencies
+install:
+  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install . --use-mirrors"


### PR DESCRIPTION
The builds can be accessed in https://travis-ci.org/glarrain/vpython-wx. After the PR is accepted, let's set up the original repo as the source for Travis CI.
