### PR TITLE
Update .travis.yml: added commands to install APT packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - "3.2"
   - "3.3"
 # command to install dependencies
+# http://about.travis-ci.org/docs/user/build-configuration/#Installing-Packages-Using-apt
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libgtk2.0-dev libgtkglextmm-x11-1.2-dev libgtkmm-2.4-dev
 install:
   - "pip install -r requirements.txt --use-mirrors"
   - "pip install . --use-mirrors"


### PR DESCRIPTION
To avoid the error building with Python 2.7

```
RuntimeError: can't find packages installed:gtkmm,gtkglext,gtkglextm
```
