### PR TITLE
Update .travis.yml: added 'xvfb' to imitate a monitor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ before_install:
   - export PYTHONPATH="$PWD/wxPython"
   - export LD_LIBRARY_PATH="$PWD/bld/lib"
   - cd ..
+# wxPython needs access to the X display, otherwise it will raise a SystemExit.
+# We need to "imitate" a monitor
+# http://about.travis-ci.org/docs/user/gui-and-headless-browsers/
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 install:
   - "pip install -r requirements.txt --use-mirrors"
   - "pip install . --use-mirrors"


### PR DESCRIPTION
Travis is still unable to complete all steps. Since it uses an OS without "desktop", it has no display for wxPython to access.

https://travis-ci.org/BruceSherwood/vpython-wx/jobs/12460550
