### PR TITLE
Minor corrections/additions to VC build instructions

### DIFF
--- a/VCBuild/VCBuild.txt
+++ b/VCBuild/VCBuild.txt
@@ -74,7 +74,7 @@ Building vpython with Visual Studio C++
 
 	Build cvisual.pyd
         32 bit: Open the VCBuild/cvisual-32bit.vcproj project file in Visual Studio Express
-        64 bit: Open the VCBuild/cvisual.sln project file in Visual Studio Express, 
+        64 bit: Open the VCBuild/cvisual27.sln project file in Visual Studio Express, 
 		Make Release the active configuration, then on the Build menu choose build or rebuild visual.
 
         The .pyd file is placed in vpython-wx\site-packages\visual_common


### PR DESCRIPTION
Most of the changes in here are fairly minor.

It is unclear which of the solution files should be used for a 32bit Release build. The solution `cvisual27.sln` contains both 32 and 64 bit configurations but the 32bit release configuration puts `cvisual.pyd` into `site-packages\vis\` rather than `site_packages\visual_common`.

The file `VCBuild/cvisual-32bit.vcproj` puts `cvisual.pyd` in the right place (`visual_common`) so I assumed it was the right one (and it worked).

There is no solution (`.sln`) file for it, which raises a warning when compiling form the command line (though it compiles just fine).
